### PR TITLE
Change delete validation to return a status error

### DIFF
--- a/pkg/strategy/delete.go
+++ b/pkg/strategy/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/acorn-io/mink/pkg/types"
+	apierror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,7 +14,7 @@ import (
 )
 
 type ValidateDeleter interface {
-	ValidateDelete(ctx context.Context, obj runtime.Object) error
+	ValidateDelete(ctx context.Context, obj runtime.Object) *apierror.StatusError
 }
 
 type Deleter interface {
@@ -83,7 +84,7 @@ func (a *DeleteAdapter) Delete(ctx context.Context, name string, deleteValidatio
 	}
 
 	if a.ValidateDeleter != nil {
-		if err = a.ValidateDeleter.ValidateDelete(ctx, tObj); err != nil {
+		if err := a.ValidateDeleter.ValidateDelete(ctx, tObj); err != nil {
 			return nil, false, err
 		}
 	}


### PR DESCRIPTION
In order to distinguish between a user error and a server error, the delete validation is changed to return a API status error. By default, if no status code is set, then it will default to 500.