### PR TITLE
Fix long-running typo in default config

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -58,7 +58,7 @@ func (c *Config) complete() {
 		c.HTTPSListenPort = c.HTTPListenPort + 1
 	}
 	if len(c.LongRunningVerbs) == 0 {
-		c.LongRunningResources = []string{"watch", "proxy"}
+		c.LongRunningVerbs = []string{"watch", "proxy"}
 	}
 	if c.Scheme == nil {
 		c.Scheme = scheme.Scheme


### PR DESCRIPTION
If the long-running verbs was empty, the long-running resources were getting set accidentally. This change fixes that typo.