### PR TITLE
Translate MySQL 1062 duplicate entry errors into HTTP 409 responses

### DIFF
--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -48,10 +48,6 @@ func newResourceVersionMismatch(gvk schema.GroupVersionKind, name string) error 
 }
 
 func translateDuplicateEntryErr(err error, gvk schema.GroupVersionKind, objName string) error {
-	if err == nil {
-		return err
-	}
-
 	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
 		return newConflict(gvk, objName, err)
 	}

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -310,26 +310,17 @@ func (s *Strategy) getExisting(ctx context.Context, gvk schema.GroupVersionKind,
 
 func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.Update(ctx, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
-		return obj, newConflict(s.gvk, obj.GetName(), err)
-	}
-	return obj, err
+	return obj, translateDuplicateEntryErr(err, s.gvk, obj.GetName())
 }
 
 func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.update(ctx, true, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
-		return obj, newConflict(s.gvk, obj.GetName(), err)
-	}
-	return obj, err
+	return obj, translateDuplicateEntryErr(err, s.gvk, obj.GetName())
 }
 
 func (s *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.update(ctx, false, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
-		return obj, newConflict(s.gvk, obj.GetName(), err)
-	}
-	return obj, err
+	return obj, translateDuplicateEntryErr(err, s.gvk, obj.GetName())
 }
 
 func strptr(s string) *string {

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/acorn-io/mink/pkg/types"
+	"github.com/go-sql-driver/mysql"
 	"gorm.io/gorm"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -308,15 +309,27 @@ func (s *Strategy) getExisting(ctx context.Context, gvk schema.GroupVersionKind,
 }
 
 func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
-	return s.Update(ctx, obj)
+	obj, err := s.Update(ctx, obj)
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+		return obj, newConflict(s.gvk, obj.GetName(), err)
+	}
+	return obj, err
 }
 
 func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
-	return s.update(ctx, true, obj)
+	obj, err := s.update(ctx, true, obj)
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+		return obj, newConflict(s.gvk, obj.GetName(), err)
+	}
+	return obj, err
 }
 
 func (s *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
-	return s.update(ctx, false, obj)
+	obj, err := s.update(ctx, false, obj)
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+		return obj, newConflict(s.gvk, obj.GetName(), err)
+	}
+	return obj, err
 }
 
 func strptr(s string) *string {
@@ -392,6 +405,9 @@ func (s *Strategy) update(ctx context.Context, status bool, obj types.Object) (t
 func (s *Strategy) Create(ctx context.Context, obj types.Object) (result types.Object, err error) {
 	err = s.db.Transaction(ctx, func(ctx context.Context) error {
 		result, err = s.create(ctx, obj)
+		if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+			return newConflict(s.gvk, obj.GetName(), err)
+		}
 		return err
 	})
 	return

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -310,7 +310,7 @@ func (s *Strategy) getExisting(ctx context.Context, gvk schema.GroupVersionKind,
 
 func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.Update(ctx, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
 		return obj, newConflict(s.gvk, obj.GetName(), err)
 	}
 	return obj, err
@@ -318,7 +318,7 @@ func (s *Strategy) Delete(ctx context.Context, obj types.Object) (types.Object, 
 
 func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.update(ctx, true, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
 		return obj, newConflict(s.gvk, obj.GetName(), err)
 	}
 	return obj, err
@@ -326,7 +326,7 @@ func (s *Strategy) UpdateStatus(ctx context.Context, obj types.Object) (types.Ob
 
 func (s *Strategy) Update(ctx context.Context, obj types.Object) (types.Object, error) {
 	obj, err := s.update(ctx, false, obj)
-	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 {
+	if err, ok := err.(*mysql.MySQLError); ok && err.Number == 1062 { // error 1062 is a duplicate entry error
 		return obj, newConflict(s.gvk, obj.GetName(), err)
 	}
 	return obj, err


### PR DESCRIPTION
We see errors pretty often in our apps that use mink and they look something like this:

`Duplicate entry '<some number>' for key 'idx_previous'`

`idx_previous` is referring to the `Previous` field on the `Record` type here in mink. Whenever an object gets updated, its `Previous` field is set to the ID of the previous version of the object.

When an object is first updated, it is read and then written. If two requests happen simultaneously, such that they both read the object at the same time and then go to update it at the same time, they will end up trying to set the same value for this `idx_previous` field, which will cause this MySQL error, which has code 1062. These changes look for this error and return an HTTP 409 Conflict to the requester.

I have no idea why this seems to happen so frequently in the wild to be honest, but this should at least make the error clearer.