### PR TITLE
Tuning max connection stream in http2

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -93,6 +93,7 @@ func New(config *Config) (*Server, error) {
 
 	opts := config.DefaultOptions
 	opts.SecureServing.BindPort = config.HTTPSListenPort
+	opts.SecureServing.HTTP2MaxStreamsPerConnection = 2500
 	opts.Authentication.SkipInClusterLookup = !config.SupportAPIAggregation
 	opts.Authentication.RemoteKubeConfigFileOptional = !config.SupportAPIAggregation
 


### PR DESCRIPTION
We are getting a lot of watch errors in cluster-agent and infra-provisioning when watching apps.

```
W0818 17:48:43.968395       1 reflector.go:456] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers.go:233: watch of *v1.ContainerReplica ended with: an error on the server ("unable to decode an event from the watch stream: stream error: stream ID 903; INTERNAL_ERROR; received from peer") has prevented the request from succeeding
```

After some investigation, I believe this is http2 stream error. Since this error only occurs in cluster that has a lot of workloads, I am thinking this might be caused by http2 performance issues which some parameters needs to be tuned. Since all the watch and api requests are coming from cluster-agent and acorn(which is from the same client(controlplane node), we could be piping too much data into one single TCP connection with limited max connection stream. So bumping it to 2500(default is 250) and we can see if it will improve the performance.