### PR TITLE
Add data encryption option to DB factory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/acorn-io/mink
 go 1.18
 
 require (
+	github.com/go-sql-driver/mysql v1.6.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	gorm.io/datatypes v1.0.7
@@ -39,7 +40,6 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
-	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -438,6 +438,7 @@ func (g *GormDB) Watch(ctx context.Context, criteria WatchCriteria) (chan Record
 				}()
 				return
 			case rec, ok := <-merged:
+				_ = g.decryptData(ctx, &rec)
 				if !ok {
 					// This means that both initialize and sub.C have been closed.
 					return

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -714,12 +714,12 @@ func (g *GormDB) decryptData(ctx context.Context, rec *Record) error {
 
 	if t, exists := g.transformers[gk]; exists {
 		logrus.Debugf("Decrypting data for record %s in namespace %s", rec.Name, rec.Namespace)
-		m := &map[string]string{}
-		if err := json.Unmarshal(rec.Data, m); err != nil {
+		m := map[string]string{}
+		if err := json.Unmarshal(rec.Data, &m); err != nil {
 			// If it doesn't unmarshal, then it wasn't encrypted by the transformer, so just return
 			return nil
 		}
-		data, err := base64.StdEncoding.DecodeString((*m)["e"])
+		data, err := base64.StdEncoding.DecodeString(m["e"])
 		if err != nil {
 			return err
 		}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -511,8 +511,8 @@ func (g *GormDB) find(ctx context.Context, db *gorm.DB, criteria Criteria) (resu
 		return result, resourceVersion, db.Error
 	}
 
-	for _, rec := range result {
-		if err := g.decryptData(ctx, &rec); err != nil {
+	for i := range result {
+		if err := g.decryptData(ctx, &result[i]); err != nil {
 			return result, resourceVersion, err
 		}
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -512,7 +512,7 @@ func (g *GormDB) find(ctx context.Context, db *gorm.DB, criteria Criteria) (resu
 	}
 
 	for i := range result {
-		if err := g.decryptRecord(ctx, &result[i]); err != nil {
+		if err := g.decryptData(ctx, &result[i]); err != nil {
 			return result, resourceVersion, err
 		}
 	}
@@ -656,7 +656,7 @@ func (g *GormDB) Transaction(ctx context.Context, do func(ctx context.Context) e
 
 func (g *GormDB) Insert(ctx context.Context, rec *Record) error {
 	defer g.triggerWatchLoop()
-	if err := g.encryptRecord(ctx, rec); err != nil {
+	if err := g.encryptData(ctx, rec); err != nil {
 		return err
 	}
 	return g.getDB(ctx).Transaction(func(tx *gorm.DB) error {
@@ -684,14 +684,14 @@ func (u uid) AuthenticatedData() []byte {
 	return []byte(u)
 }
 
-func (g *GormDB) encryptRecord(ctx context.Context, rec *Record) error {
+func (g *GormDB) encryptData(ctx context.Context, rec *Record) error {
 	gr := schema.GroupResource{
 		Group: rec.APIGroup,
 		// This is a hack to convert Kind to Resource. Resource is supposed to be the lowercase and plural of Kind.
 		// We will expect the provided EncryptionConfiguration to use lowercase and singular for the resource names instead, to make this easier.
 		Resource: strings.ToLower(rec.Kind),
 	}
-	logrus.Debugf("(encryptRecord) Finding transformer for GroupResource: %s", gr.String())
+	logrus.Debugf("(encryptData) Finding transformer for GroupResource: %s", gr.String())
 
 	if t, exists := g.transformers[gr]; exists {
 		logrus.Debugf("Encrypting data for record %s in namespace %s", rec.Name, rec.Namespace)
@@ -708,23 +708,21 @@ func (g *GormDB) encryptRecord(ctx context.Context, rec *Record) error {
 	return nil
 }
 
-func (g *GormDB) decryptRecord(ctx context.Context, rec *Record) error {
+func (g *GormDB) decryptData(ctx context.Context, rec *Record) error {
 	gr := schema.GroupResource{
 		Group: rec.APIGroup,
 		// This is a hack to convert Kind to Resource. Resource is supposed to be the lowercase and plural of Kind.
 		// We will expect the provided EncryptionConfiguration to use lowercase and singular for the resource names instead, to make this easier.
 		Resource: strings.ToLower(rec.Kind),
 	}
-	logrus.Debugf("(decryptRecord) Finding transformer for GroupResource: %s", gr.String())
+	logrus.Debugf("(decryptData) Finding transformer for GroupResource: %s", gr.String())
 
 	if t, exists := g.transformers[gr]; exists {
 		logrus.Debugf("Decrypting data for record %s in namespace %s", rec.Name, rec.Namespace)
 		m := &map[string]string{}
 		if err := json.Unmarshal(rec.Data, m); err != nil {
-			// This table is not encrypted, but needs to be, so encrypt all records in it
-			if err := g.encryptTable(ctx); err != nil {
-				return fmt.Errorf("error while encrypting table for GVK %s: %w", g.gvk.String(), err)
-			}
+			// If it doesn't unmarshal, then it wasn't encrypted by the transformer, so just return
+			return nil
 		}
 		data, err := base64.StdEncoding.DecodeString((*m)["e"])
 		if err != nil {
@@ -733,44 +731,6 @@ func (g *GormDB) decryptRecord(ctx context.Context, rec *Record) error {
 
 		rec.Data, _, err = t.TransformFromStorage(ctx, data, uid(rec.UID))
 		return err
-	}
-	return nil
-}
-
-func (g *GormDB) encryptTable(ctx context.Context) error {
-	gr := schema.GroupResource{
-		Group:    g.gvk.Group,
-		Resource: strings.ToLower(g.gvk.Kind),
-	}
-	logrus.Debugf("(encryptTable) Finding transformer for GroupResource: %s", gr.String())
-
-	if _, exists := g.transformers[gr]; exists {
-		logrus.Debugf("Encrypting entire table for GVK %s", g.gvk.String())
-
-		var records []Record
-		db := g.getDB(ctx).Table(g.tableName).Find(&records)
-		if db.Error != nil {
-			return db.Error
-		}
-
-		for i := range records {
-			if err := g.encryptRecord(ctx, &records[i]); err != nil {
-				return err
-			}
-		}
-
-		if len(records) > 0 {
-			return g.getDB(ctx).Transaction(func(tx *gorm.DB) error {
-				tx = tx.WithContext(ctx)
-				for _, rec := range records {
-					db := tx.Table(g.tableName).Where("id = ?", rec.ID).Update("data", rec.Data)
-					if db.Error != nil {
-						return db.Error
-					}
-				}
-				return nil
-			})
-		}
 	}
 	return nil
 }

--- a/pkg/db/factory.go
+++ b/pkg/db/factory.go
@@ -16,6 +16,9 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
+	"k8s.io/apiserver/pkg/storage/value"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -25,6 +28,7 @@ type Factory struct {
 	schema           *runtime.Scheme
 	migrationTimeout time.Duration
 	AutoMigrate      bool
+	transformers     map[schema.GroupResource]value.Transformer
 }
 
 type FactoryOption func(*Factory)
@@ -34,6 +38,19 @@ func WithMigrationTimeout(timeout time.Duration) FactoryOption {
 	return func(f *Factory) {
 		f.migrationTimeout = timeout
 	}
+}
+
+func WithEncryptionConfiguration(ctx context.Context, configPath string) (FactoryOption, error) {
+	encryptionConf, err := encryptionconfig.LoadEncryptionConfig(ctx, configPath, false)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Transformers: %+v", encryptionConf.Transformers)
+
+	return func(f *Factory) {
+		f.transformers = encryptionConf.Transformers
+	}, nil
 }
 
 func NewFactory(schema *runtime.Scheme, dsn string, opts ...FactoryOption) (*Factory, error) {
@@ -128,7 +145,7 @@ func (f *Factory) NewDBStrategy(obj types.Object) (strategy.CompleteStrategy, er
 			}
 		}
 	}
-	s, err := NewStrategy(f.schema, obj, tableName, f.db)
+	s, err := NewStrategy(f.schema, obj, tableName, f.db, f.transformers)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/factory.go
+++ b/pkg/db/factory.go
@@ -46,8 +46,6 @@ func WithEncryptionConfiguration(ctx context.Context, configPath string) (Factor
 		return nil, err
 	}
 
-	logrus.Infof("Transformers: %+v", encryptionConf.Transformers)
-
 	return func(f *Factory) {
 		f.transformers = encryptionConf.Transformers
 	}, nil

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
+	"k8s.io/apiserver/pkg/storage/value"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -36,7 +37,7 @@ type cont struct {
 	ID uint `json:"id,omitempty"`
 }
 
-func NewStrategy(scheme *runtime.Scheme, obj runtime.Object, tableName string, db *gorm.DB) (*Strategy, error) {
+func NewStrategy(scheme *runtime.Scheme, obj runtime.Object, tableName string, db *gorm.DB, transformers map[schema.GroupResource]value.Transformer) (*Strategy, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
 		return nil, err
@@ -55,7 +56,7 @@ func NewStrategy(scheme *runtime.Scheme, obj runtime.Object, tableName string, d
 	})
 	s := &Strategy{
 		scheme:  scheme,
-		db:      NewDB(tableName, gvk, db),
+		db:      NewDB(tableName, gvk, db, transformers),
 		gvk:     gvk,
 		obj:     obj,
 		objList: objList,

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -37,7 +37,7 @@ type cont struct {
 	ID uint `json:"id,omitempty"`
 }
 
-func NewStrategy(scheme *runtime.Scheme, obj runtime.Object, tableName string, db *gorm.DB, transformers map[schema.GroupResource]value.Transformer) (*Strategy, error) {
+func NewStrategy(scheme *runtime.Scheme, obj runtime.Object, tableName string, db *gorm.DB, transformers map[schema.GroupKind]value.Transformer) (*Strategy, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Here is how this works:

We use a [Kubernetes EncryptionConfiguration file](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) to configure Mink to talk with a KMS plugin to encrypt data.

For each Record that it will write to the database, Mink will call out to the KMS plugin to encrypt the data field, and then write the Record with the data field in the JSON format: `"e": "<base64 of the encrypted data>"`.

When reading Records, Mink gets the data from the DB, extracts the `e` field from the data, then calls out to the KMS plugin to decrypt the data.

The encryption and decryption operations are done using a "Transformer" object, which is created by the k8s code that we are using for this.

One other thing to note, the UID of the Record is being used to fulfill the value.Context interface. More info on this in comments in the code. In the k8s apiserver code, they are using the key of the object in etcd, so this seemed like the most closely analogous thing.