### PR TITLE
add default updated value

### DIFF
--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -552,6 +552,7 @@ func (s *Strategy) objectToRecord(obj types.Object) (*Record, error) {
 		Generation: 1,
 		Previous:   nil,
 		Created:    time.Now(),
+		Updated:    time.Now(),
 		Metadata:   metadataData,
 		Data:       specData,
 		Status:     statusData,


### PR DESCRIPTION
This fixes #25 by adding a default time.Now() value when converting objects to records. 
