### PR TITLE
Add partition ID for a multi-tenant approach to databases

### DIFF
--- a/pkg/db/context.go
+++ b/pkg/db/context.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"context"
+)
+
+type partitionIDKey struct{}
+
+func ContextWithPartitionID(ctx context.Context, partitionID string) context.Context {
+	if partitionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, partitionIDKey{}, partitionID)
+}
+
+func PartitionIDFromContext(ctx context.Context) string {
+	// Don't panic
+	id, _ := ctx.Value(partitionIDKey{}).(string)
+	return id
+}

--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -53,3 +53,7 @@ func translateDuplicateEntryErr(err error, gvk schema.GroupVersionKind, objName 
 	}
 	return err
 }
+
+func newPartitionRequiredError() error {
+	return apierrors.NewInternalError(fmt.Errorf("partition ID required"))
+}

--- a/pkg/db/strategy_test.go
+++ b/pkg/db/strategy_test.go
@@ -36,7 +36,7 @@ func newTestStore(t *testing.T) *Strategy {
 		t.Fatal(err)
 	}
 
-	s, err := NewStrategy(scheme.Scheme, &corev1.Pod{}, "pod", db)
+	s, err := NewStrategy(scheme.Scheme, &corev1.Pod{}, "pod", db, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -10,25 +10,26 @@ import (
 )
 
 type Record struct {
-	ID         uint
-	Kind       string
-	Version    string
-	APIGroup   string
-	Name       string `gorm:"index:idx_ns_name"`
-	Namespace  string `gorm:"index:idx_ns_name"`
-	UID        string
-	Generation int
-	Previous   *uint `gorm:"index:idx_previous,unique"`
-	Create     bool
-	Created    time.Time
-	Updated    time.Time
-	Deleted    *time.Time
-	Removed    *time.Time
-	Garbage    bool `gorm:"index:idx_garbage;not null;default:0"`
-	Latest     bool `gorm:"index:idx_latest;default:0"`
-	Metadata   datatypes.JSON
-	Data       datatypes.JSON
-	Status     datatypes.JSON
+	ID          uint
+	Kind        string
+	Version     string
+	APIGroup    string
+	Name        string `gorm:"index:idx_ns_name_id"`
+	Namespace   string `gorm:"index:idx_ns_name_id"`
+	UID         string
+	Generation  int
+	Previous    *uint `gorm:"index:idx_previous,unique"`
+	Create      bool
+	Created     time.Time
+	Updated     time.Time
+	Deleted     *time.Time
+	Removed     *time.Time
+	Garbage     bool `gorm:"index:idx_garbage;not null;default:0"`
+	Latest      bool `gorm:"index:idx_latest;default:0"`
+	Metadata    datatypes.JSON
+	Data        datatypes.JSON
+	Status      datatypes.JSON
+	PartitionID string `gorm:"index:idx_ns_name_id"`
 }
 
 type WatchCriteria struct {
@@ -36,6 +37,7 @@ type WatchCriteria struct {
 	Namespace     *string
 	After         uint
 	LabelSelector labels.Selector
+	PartitionID   string
 }
 
 type Criteria struct {
@@ -51,6 +53,7 @@ type Criteria struct {
 	FieldSelector     fields.Selector
 	IncludeDeleted    bool
 	IncludeGC         bool
+	PartitionID       string
 
 	ignoreCompactionCheck bool
 }


### PR DESCRIPTION
A partition ID is added to the database strategy to allow for multi-tenant storage in the database layer. A parameter is added to the database factory to make the partition ID required for all requests. If the partition ID is required and none is put on the context, then an internal server error is returned.