### PR TITLE
Log SQL executions at Trace instead of Debug

### DIFF
--- a/pkg/db/glogrus/glogrus.go
+++ b/pkg/db/glogrus/glogrus.go
@@ -100,7 +100,7 @@ func (l *Logger) Trace(ctx context.Context, begin time.Time, fc func() (string, 
 		return
 	}
 
-	log.Debug("sql query executed")
+	log.Trace("sql query executed")
 }
 
 // complete ensures that the Logger is fully initialized.


### PR DESCRIPTION
Logging every time SQL is executed is overly verbose at the debug level.
Log them at Trace instead.

