### PR TITLE
Aggregator functionality

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apiserver v0.29.0
 	k8s.io/client-go v0.29.0
 	k8s.io/klog/v2 v2.110.1
+	k8s.io/kube-aggregator v0.29.0
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.12.3
@@ -62,6 +63,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -510,6 +512,8 @@ k8s.io/klog/v2 v2.110.1 h1:U/Af64HJf7FcwMcXyKm2RPM22WZzyR7OSpYj5tg3cL0=
 k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 k8s.io/kms v0.29.0 h1:KJ1zaZt74CgvgV3NR7tnURJ/mJOKC5X3nwon/WdwgxI=
 k8s.io/kms v0.29.0/go.mod h1:mB0f9HLxRXeXUfHfn1A7rpwOlzXI1gIWu86z6buNoYA=
+k8s.io/kube-aggregator v0.29.0 h1:N4fmtePxOZ+bwiK1RhVEztOU+gkoVkvterHgpwAuiTw=
+k8s.io/kube-aggregator v0.29.0/go.mod h1:bjatII63ORkFg5yUFP2qm2OC49R0wwxZhRVIyJ4Z4X0=
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/AuzbMm96cd3YHRTU83I780=
 k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -1,0 +1,180 @@
+package aggregator
+
+import (
+	"fmt"
+	minkopenapi "github.com/acorn-io/mink/pkg/openapi"
+	"github.com/acorn-io/mink/pkg/proxy"
+	minkserver "github.com/acorn-io/mink/pkg/server"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/apidiscovery/v2beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+// Delegate represents a "downstream" api server.
+type Delegate struct {
+	Config *rest.Config
+}
+
+// URL returns a url.URL from the Delegate's rest config
+func (d *Delegate) URL() *url.URL {
+	ret, err := url.Parse(d.Config.Host)
+	if err == nil {
+		return ret
+	}
+
+	return &url.URL{
+		Host:   d.Config.Host,
+		Path:   d.Config.APIPath,
+		Scheme: "https",
+	}
+}
+
+// Config holds mink server config as well as the list of delegates which this aggregator
+// shall "consume".
+type Config struct {
+	minkserver.Config
+	Delegates []*Delegate
+}
+
+// NewAggregator creates a new aggregator (returned mink server w/ agggregation functionality) for the given config
+func NewAggregator(config *Config) (*minkserver.Server, error) {
+	serverConfig, err := minkserver.Prep(&config.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	// we are going to register our own handlers for /openapi/v{2,3}
+	serverConfig.SkipOpenAPIInstallation = true
+
+	serverConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
+		sets.NewString(config.LongRunningVerbs...),
+		sets.NewString(config.LongRunningResources...),
+	)
+
+	// likely already enabled but just to be safe
+	serverConfig.EnableDiscovery = true
+
+	svr, err := serverConfig.Complete().New(config.Name, server.NewEmptyDelegateWithCustomHandler(http.NotFoundHandler()))
+	if err != nil {
+		return nil, err
+	}
+
+	// we need a spec proxier in order to serve v2, or proxy v3 if the delegate supports it
+	specProxier := minkopenapi.New()
+
+	wg := sync.WaitGroup{}
+
+	for _, delegate := range config.Delegates {
+		delegate := delegate // var capture
+
+		go func() {
+			wg.Add(1)
+			defer wg.Done()
+
+			// build a proxy handler for this delegate
+			transportConfig, err := delegate.Config.TransportConfig()
+			if err != nil {
+				logrus.Errorf("error converting restconfig to transportconfig: %s", err.Error())
+				return
+			}
+			proxyHandler, err := proxy.New(delegate.URL(), transportConfig)
+			if err != nil {
+				logrus.Errorf("error building proxy handler for endpoint %s: %s", delegate.URL().String(), err.Error())
+				return
+			}
+
+			// get a list of api groups and resources for the delegate
+			// this is how we register group- and resource-specific handlers
+			apiGroupList, apiResources, err := getAPIGroups(delegate)
+			if err != nil {
+				logrus.Error(err)
+				return
+			}
+
+			// in order to serve up the discovery endpoint at `/apis` we need to
+			// register the api group with GenericAPIServer.DiscoveryGroupManager
+			for _, apiGroup := range apiGroupList {
+				logrus.Infof("registering apigroup %s into DiscoveryGroupManager\n", apiGroup.Name)
+				svr.DiscoveryGroupManager.AddGroup(*apiGroup)
+			}
+
+			for _, resources := range apiResources {
+				// legacy resources (e.g. nodes, pods, configmaps, et al) need to be served by `/api/v1` handlers
+				// everything else is group named and served under `/apis`
+				if resources.GroupVersion == "" || resources.GroupVersion == "v1" {
+					// register legacy handler
+					svr.Handler.NonGoRestfulMux.Handle("/api/v1", proxyHandler)
+					svr.Handler.NonGoRestfulMux.HandlePrefix("/api/v1/", proxyHandler)
+				} else {
+					svr.Handler.NonGoRestfulMux.Handle("/apis/"+resources.GroupVersion, proxyHandler)
+					svr.Handler.NonGoRestfulMux.HandlePrefix("/apis/"+resources.GroupVersion+"/", proxyHandler)
+				}
+
+				gv, err := schema.ParseGroupVersion(resources.GroupVersion)
+				if err != nil {
+					logrus.Error(err)
+					return
+				}
+
+				apiResourceDiscovery, err := endpoints.ConvertGroupVersionIntoToDiscovery(resources.APIResources)
+				if err != nil {
+					logrus.Error(err)
+					return
+				}
+
+				// this registration powers the ability of the aggregator to correctly return v2beta1.APIVersionDiscovery
+				// lists to clients. this is necessary mostly to power calls such as `kubectl api-resources` which requests
+				// `/apis` but returning specifically `g=apidiscovery.k8s.io;v=v2beta1;as=APIGroupDiscoveryList`
+				svr.AggregatedDiscoveryGroupManager.AddGroupVersion(gv.Group, v2beta1.APIVersionDiscovery{
+					Version:   gv.Version,
+					Resources: apiResourceDiscovery,
+					Freshness: v2beta1.DiscoveryFreshnessCurrent,
+				})
+			}
+
+			// register the delegate with the specProxie
+			if err := specProxier.Register(proxyHandler); err != nil {
+				logrus.Error(err)
+				return
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// install the spec proxier's handlers into the GenericAPIServer's NonGoRestfulMux
+	// this is what causes the GenericAPIServer to serve /openapi/v{2,3}
+	// when serverConfig.SkipOpenAPIInstallation = true
+	specProxier.InstallV2(svr.Handler.NonGoRestfulMux)
+	specProxier.InstallV3(svr.Handler.NonGoRestfulMux)
+
+	return &minkserver.Server{
+		MinkConfig:       &config.Config,
+		Config:           serverConfig,
+		GenericAPIServer: svr,
+	}, nil
+}
+
+// getAPIGroups builds a discovery client which calls discovery on /api and /apis
+// for the delegate. It returns a list of api groups and api resources which we utilize to register
+// handlers for the aggregator.
+func getAPIGroups(delegate *Delegate) ([]*v1.APIGroup, []*v1.APIResourceList, error) {
+	discoveryEndpoint := delegate.URL().String()
+
+	dc, err := discovery.NewDiscoveryClientForConfig(delegate.Config)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating discovery client for endpoint %s: %s", discoveryEndpoint, err.Error())
+	}
+
+	return dc.ServerGroupsAndResources()
+}

--- a/pkg/openapi/proxy.go
+++ b/pkg/openapi/proxy.go
@@ -1,0 +1,210 @@
+package openapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator"
+	aggregator3 "k8s.io/kube-aggregator/pkg/controllers/openapiv3/aggregator"
+	"k8s.io/kube-openapi/pkg/handler"
+	"k8s.io/kube-openapi/pkg/handler3"
+	"k8s.io/kube-openapi/pkg/openapiconv"
+	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// CanHandle defines an interface for resources that can handle http paths via a passed path and handler
+type CanHandle interface {
+	Handle(path string, handler http.Handler)
+}
+
+// CanHandlePrefix defines an interface for resources that can handle
+// http paths ending with "/" via a passed path and handler.
+// This interface does not (cannot) enforce path ending with a "/", it is up to the implementation to do that.
+type CanHandlePrefix interface {
+	HandlePrefix(path string, handler http.Handler)
+}
+
+// CanHandleWithPrefix defines an interface for resources that can both Handle() and HandlePrefix()
+type CanHandleWithPrefix interface {
+	CanHandle
+	CanHandlePrefix
+}
+
+// Endpoint stores the handler and DiscoveryGroupVersion for an OpenAPI v3 endpoint.
+// This is used when calling SpecProxier.HandleGroupVersion to serve http via the http.Handler,
+// as well as constructing openapi v3 discovery root via SpecProxier.HandleDiscovery
+type Endpoint struct {
+	Handler http.Handler
+	DGV     handler3.OpenAPIV3DiscoveryGroupVersion
+}
+
+// SpecProxier either proxies or serves openapi spec. It is the proxy middleware between
+// an aggregator and delegate api servers. The proxier does not itself perform proxying
+// but rather relies on an http.Handler to do this
+type SpecProxier struct {
+	mutex     sync.Mutex
+	Discovery map[string]Endpoint
+
+	v2Service *handler.OpenAPIService
+
+	v3Spec *spec3.OpenAPI
+}
+
+// New creates a new SpecProxier
+func New() *SpecProxier {
+	return &SpecProxier{
+		v2Service: handler.NewOpenAPIService(nil),
+		Discovery: map[string]Endpoint{},
+	}
+}
+
+// Register will attempt to register OpenAPI v2 & v3 spec for the passed handler.
+// It is expected that v2 will always be available, but v3 may not be.
+// In that case, v2 will be converted to v3 using openapiconv.ConvertV2ToV3
+// and then served directly. Otherwise if v3 is available, the discovery root
+// will be downloaded and merged into the SpecProxier's discovery map
+func (s *SpecProxier) Register(handler http.Handler) error {
+	swagger, err := s.downloadV2(handler)
+	if err != nil {
+		return err
+	}
+
+	if err = s.v2Service.UpdateSpec(swagger); err != nil {
+		return err
+	}
+
+	// try to get v3 discovery root
+	v3Root, err := s.downloadV3(handler)
+	if err != nil {
+		return err
+	}
+
+	if v3Root == nil {
+		// no v3 at endpoint. convert & serve v2
+		s.v3Spec = openapiconv.ConvertV2ToV3(swagger)
+	} else {
+		s.RegisterRoot(v3Root, handler)
+	}
+
+	return nil
+}
+
+// downloadV2 downloads the openapi v2 spec from the http.Handler.
+func (s *SpecProxier) downloadV2(handler http.Handler) (*spec.Swagger, error) {
+	v2Downloader := aggregator.NewDownloader()
+
+	v2Spec, _, _, err := v2Downloader.Download(handler, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return v2Spec, nil
+}
+
+// downloadV3 downloads the openapiv3 root from the http.Handler.
+func (s *SpecProxier) downloadV3(handler http.Handler) (*handler3.OpenAPIV3Discovery, error) {
+	downloader := aggregator3.NewDownloader()
+
+	root, _, err := downloader.OpenAPIV3Root(handler)
+
+	return root, err
+}
+
+// RegisterRoot takes a v3 openapi root, and an http.Handler. Iterating over the paths in v3Root,
+// the handler is registered as the handler for that path. This is how new v3 roots are merged
+// into Discovery and later served via HandleDiscovery
+func (s *SpecProxier) RegisterRoot(v3Root *handler3.OpenAPIV3Discovery, handler http.Handler) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	// enumerate paths, register into local discovery
+	for path, dgv := range v3Root.Paths {
+		s.Discovery[path] = Endpoint{
+			Handler: handler,
+			DGV:     dgv,
+		}
+	}
+}
+
+// HandleDiscovery returns either the openapi v3 root doc (with relative paths, etc.), or if
+// the delegate doesn't support v3, it serves the v3 spec (which has been converted from v2 and stored)
+func (s *SpecProxier) HandleDiscovery(w http.ResponseWriter, r *http.Request) {
+	var out any
+	if s.v3Spec != nil {
+		out = s.v3Spec
+	} else {
+		out = s.V3Root()
+	}
+
+	serveJSON(out, w, r)
+}
+
+// HandleGroupVersion returns either a proxied result from the delegate's openapi v3 handler for a specific path,
+// or it serves up the specifically requested path from the saved v3Spec (converted from v2) in the case of the
+// delegate not supporting openapi v3.
+func (s *SpecProxier) HandleGroupVersion(w http.ResponseWriter, r *http.Request) {
+	// /openapi/v3/example.com/blah
+	parts := strings.SplitAfterN(r.URL.Path, "/", 4)
+
+	targetGroupVersion := parts[3]
+
+	if s.v3Spec != nil {
+		out := s.v3Spec.Paths.Paths[targetGroupVersion]
+
+		serveJSON(out, w, r)
+		return
+	}
+
+	for k, v := range s.Discovery {
+		if targetGroupVersion == k {
+			v.Handler.ServeHTTP(w, r)
+			return
+		}
+	}
+
+	w.WriteHeader(404)
+}
+
+// V3Root returns the OpenAPIV3Discovery struct stored by the SpecProxier
+func (s *SpecProxier) V3Root() handler3.OpenAPIV3Discovery {
+	merged := map[string]handler3.OpenAPIV3DiscoveryGroupVersion{}
+	for k, p := range s.Discovery {
+		merged[k] = p.DGV
+	}
+
+	return handler3.OpenAPIV3Discovery{
+		Paths: merged,
+	}
+}
+
+// InstallV2 installs the /openapi/v2 handler into a CanHandle implementation.
+// Typically, the CanHandle is going to be a server.GenericAPIServer's Handler.NonGoRestfulMux
+func (s *SpecProxier) InstallV2(server CanHandle) {
+	s.v2Service.RegisterOpenAPIVersionedService("/openapi/v2", server)
+
+	//server.Handle("/openapi/v2", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	//	serveJSON(s.v2Spec, w, r)
+	//}))
+}
+
+// InstallV3 installs the /openapi/v3 handler into a CanHandleWithPrefix implementation.
+// Typically, the CanHandleWithPrefix is going to be a server.GenericAPIServer's Handler.NonGoRestfulMux
+func (s *SpecProxier) InstallV3(server CanHandleWithPrefix) {
+	server.Handle("/openapi/v3", http.HandlerFunc(s.HandleDiscovery))
+	server.HandlePrefix("/openapi/v3/", http.HandlerFunc(s.HandleGroupVersion))
+}
+
+// serveJSON buffers the bytes of, encodes, and then serves the content of obj
+func serveJSON(obj any, w http.ResponseWriter, r *http.Request) {
+	buf := bytes.NewBuffer([]byte{})
+
+	json.NewEncoder(buf).Encode(obj)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	http.ServeContent(w, r, "", time.Now(), bytes.NewReader(buf.Bytes()))
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+	"k8s.io/apimachinery/pkg/util/proxy"
+	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
+	"k8s.io/client-go/transport"
+	"net/http"
+	"net/url"
+)
+
+// ErrorResponder is an implementation of proxy.ErrorResponder
+type ErrorResponder struct {
+	w http.ResponseWriter
+}
+
+// Handler is a struct that stores a round tripper for a given URL with transport configuration.
+// It acts as the proxy for calls made to an aggregator which need to be served by a delegate api server.
+type Handler struct {
+	transportConfig *transport.Config
+	roundTripper    http.RoundTripper
+	url             *url.URL
+}
+
+// New creates a new Handler
+func New(url *url.URL, transportConfig *transport.Config) (*Handler, error) {
+	rt, err := transport.New(transportConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Handler{
+		transportConfig: transportConfig,
+		url:             url,
+		roundTripper:    rt,
+	}, nil
+}
+
+// ServeHTTP handles http requests by proxying the request to Handler's URL via
+// the Handler's roundTripper. It uses proxy.NewUpgradeAwareHandler to wrap the transport and serve
+// the content from the proxied call.
+func (p *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	upgrade := httpstream.IsUpgradeRequest(r)
+
+	location := &url.URL{}
+	location.Host = p.url.Host
+	location.Path = r.URL.Path
+	location.RawQuery = r.URL.Query().Encode()
+	location.Scheme = p.url.Scheme
+
+	handler := proxy.NewUpgradeAwareHandler(location, p.roundTripper, true, upgrade, ErrorResponder{w: w})
+
+	handler.ServeHTTP(w, r)
+}
+
+func (e ErrorResponder) Object(statusCode int, obj runtime.Object) {
+	responsewriters.WriteRawJSON(statusCode, obj, e.w)
+}
+
+func (e ErrorResponder) Error(_ http.ResponseWriter, _ *http.Request, err error) {
+	http.Error(e.w, err.Error(), http.StatusServiceUnavailable)
+}


### PR DESCRIPTION
First run at aggregator functionality for mink.

This will serve delegate api servers by passing their rest.configs to NewAggregator

Supports openapi v2, v3

only supports one legacy server at a time
