### PR TITLE
enhance: enable watch field selectors

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -375,6 +375,7 @@ func (g *GormDB) initializeWatch(ctx context.Context, criteria WatchCriteria, re
 			Namespace:             criteria.Namespace,
 			After:                 after,
 			LabelSelector:         criteria.LabelSelector,
+			FieldSelector:         criteria.FieldSelector,
 			Limit:                 1000,
 			Before:                before,
 			ignoreCompactionCheck: true,

--- a/pkg/db/strategy.go
+++ b/pkg/db/strategy.go
@@ -138,6 +138,7 @@ func (s *Strategy) Watch(ctx context.Context, namespace string, opts storage.Lis
 	criteria := WatchCriteria{
 		Namespace:     nilOnEmpty(namespace),
 		LabelSelector: opts.Predicate.Label,
+		FieldSelector: opts.Predicate.Field,
 		PartitionID:   partitionID,
 	}
 	name, ok := opts.Predicate.MatchesSingle()

--- a/pkg/db/types.go
+++ b/pkg/db/types.go
@@ -37,6 +37,7 @@ type WatchCriteria struct {
 	Namespace     *string
 	After         uint
 	LabelSelector labels.Selector
+	FieldSelector fields.Selector
 	PartitionID   string
 }
 

--- a/pkg/strategy/attr.go
+++ b/pkg/strategy/attr.go
@@ -1,0 +1,39 @@
+package strategy
+
+import (
+	"github.com/acorn-io/mink/pkg/types"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/storage"
+)
+
+func defaultGetAttr(scoper NamespaceScoper) storage.AttrFunc {
+	return func(obj runtime.Object) (labels.Set, fields.Set, error) {
+		ls, fs := labels.Set{}, fields.Set{}
+
+		var baseFunc storage.AttrFunc = storage.DefaultNamespaceScopedAttr
+		if !scoper.NamespaceScoped() {
+			baseFunc = storage.DefaultClusterScopedAttr
+		}
+
+		l, f, err := baseFunc(obj)
+		if err != nil {
+			return nil, nil, err
+		}
+		for k, v := range l {
+			ls[k] = v
+		}
+		for k, v := range f {
+			fs[k] = v
+		}
+
+		if f, ok := obj.(types.Fields); ok {
+			for _, field := range f.FieldNames() {
+				fs[field] = f.Get(field)
+			}
+		}
+
+		return ls, fs, nil
+	}
+}

--- a/pkg/strategy/watch.go
+++ b/pkg/strategy/watch.go
@@ -100,10 +100,10 @@ func (w *WatchAdapter) predicate(label labels.Selector, field fields.Selector) s
 		Label: label,
 		Field: field,
 	}
-	if w.NamespaceScoped() {
-		result.GetAttrs = storage.DefaultNamespaceScopedAttr
+	if attr, ok := w.strategy.(GetAttr); ok {
+		result.GetAttrs = attr.GetAttr
 	} else {
-		result.GetAttrs = storage.DefaultClusterScopedAttr
+		result.GetAttrs = defaultGetAttr(w)
 	}
 	return result
 }


### PR DESCRIPTION
Enable the use of watch field selectors by passing exposed fields
down to the underlying GormDB Strategy.

